### PR TITLE
Fat VC の回避

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD945F6244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift */; };
 		BFD94601244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift */; };
+		DAE8D9A329191D0600931C32 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A229191D0600931C32 /* Repository.swift */; };
+		DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A62919538000931C32 /* SearchResponse.swift */; };
+		DAE8D9A92919574700931C32 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A82919574700931C32 /* User.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +57,9 @@
 		DAA00AEA2914FABD00EB1481 /* README_Git.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Git.md; sourceTree = "<group>"; };
 		DAA00AEB2915009100EB1481 /* README_SwiftLint.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_SwiftLint.md; sourceTree = "<group>"; };
 		DAA00AED291500F700EB1481 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		DAE8D9A229191D0600931C32 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
+		DAE8D9A62919538000931C32 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
+		DAE8D9A82919574700931C32 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,8 +113,8 @@
 		BFD945DD244DC5E80012785A /* iOSEngineerCodeCheck */ = {
 			isa = PBXGroup;
 			children = (
+				DAE8D9A1291909D800931C32 /* Models */,
 				DACA2BD22917BDCE002989E0 /* ViewControllers */,
-				DACA2BD12917BDC4002989E0 /* Models */,
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
@@ -137,13 +143,6 @@
 			path = iOSEngineerCodeCheckUITests;
 			sourceTree = "<group>";
 		};
-		DACA2BD12917BDC4002989E0 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
 		DACA2BD22917BDCE002989E0 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -151,6 +150,16 @@
 				BF0A658C244F2A3B00280FA6 /* RepositoryDetailViewController.swift */,
 			);
 			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		DAE8D9A1291909D800931C32 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				DAE8D9A62919538000931C32 /* SearchResponse.swift */,
+				DAE8D9A229191D0600931C32 /* Repository.swift */,
+				DAE8D9A82919574700931C32 /* User.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -296,7 +305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  swiftlint autocorrect --format\n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -307,8 +316,11 @@
 			files = (
 				BFD945E3244DC5E80012785A /* RepositoryListViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
+				DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */,
+				DAE8D9A329191D0600931C32 /* Repository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				DAE8D9A92919574700931C32 /* User.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C02919FC8800931C32 /* GitHubAPIServiceProtocol.swift */; };
 		DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C22919FCB000931C32 /* GitHubAPIServiceError.swift */; };
 		DAE8D9C5291A3AB500931C32 /* GitHubAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C4291A3AB500931C32 /* GitHubAPIError.swift */; };
+		DAE8D9CD291B32A700931C32 /* RepositoryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9CC291B32A700931C32 /* RepositoryDetailViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		DAE8D9C02919FC8800931C32 /* GitHubAPIServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIServiceProtocol.swift; sourceTree = "<group>"; };
 		DAE8D9C22919FCB000931C32 /* GitHubAPIServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIServiceError.swift; sourceTree = "<group>"; };
 		DAE8D9C4291A3AB500931C32 /* GitHubAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIError.swift; sourceTree = "<group>"; };
+		DAE8D9CC291B32A700931C32 /* RepositoryDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +133,7 @@
 		BFD945DD244DC5E80012785A /* iOSEngineerCodeCheck */ = {
 			isa = PBXGroup;
 			children = (
+				DAE8D9CB291AA36C00931C32 /* ViewModels */,
 				DAE8D9AF2919F2ED00931C32 /* Service */,
 				DAE8D9A1291909D800931C32 /* Models */,
 				DACA2BD22917BDCE002989E0 /* ViewControllers */,
@@ -211,6 +214,14 @@
 				DAE8D9BE2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift */,
 			);
 			path = GitHubAPIService;
+			sourceTree = "<group>";
+		};
+		DAE8D9CB291AA36C00931C32 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				DAE8D9CC291B32A700931C32 /* RepositoryDetailViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -367,6 +378,7 @@
 			files = (
 				DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositoryListViewController.swift in Sources */,
+				DAE8D9CD291B32A700931C32 /* RepositoryDetailViewModel.swift in Sources */,
 				DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -19,6 +19,15 @@
 		DAE8D9A329191D0600931C32 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A229191D0600931C32 /* Repository.swift */; };
 		DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A62919538000931C32 /* SearchResponse.swift */; };
 		DAE8D9A92919574700931C32 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A82919574700931C32 /* User.swift */; };
+		DAE8D9B12919F2F500931C32 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9B02919F2F500931C32 /* HTTPMethod.swift */; };
+		DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9B52919F33B00931C32 /* GitHubAPIRequest.swift */; };
+		DAE8D9B82919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9B72919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift */; };
+		DAE8D9BA2919F38D00931C32 /* GitHubAPIRequestProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9B92919F38D00931C32 /* GitHubAPIRequestProtocol.swift */; };
+		DAE8D9BC2919FC4500931C32 /* GitHubAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9BB2919FC4500931C32 /* GitHubAPIService.swift */; };
+		DAE8D9BF2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9BE2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift */; };
+		DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C02919FC8800931C32 /* GitHubAPIServiceProtocol.swift */; };
+		DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C22919FCB000931C32 /* GitHubAPIServiceError.swift */; };
+		DAE8D9C5291A3AB500931C32 /* GitHubAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9C4291A3AB500931C32 /* GitHubAPIError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +69,15 @@
 		DAE8D9A229191D0600931C32 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		DAE8D9A62919538000931C32 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
 		DAE8D9A82919574700931C32 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		DAE8D9B02919F2F500931C32 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		DAE8D9B52919F33B00931C32 /* GitHubAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIRequest.swift; sourceTree = "<group>"; };
+		DAE8D9B72919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubAPIRequest+SearchRepositories.swift"; sourceTree = "<group>"; };
+		DAE8D9B92919F38D00931C32 /* GitHubAPIRequestProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIRequestProtocol.swift; sourceTree = "<group>"; };
+		DAE8D9BB2919FC4500931C32 /* GitHubAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIService.swift; sourceTree = "<group>"; };
+		DAE8D9BE2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubAPIService+SearchRepositories.swift"; sourceTree = "<group>"; };
+		DAE8D9C02919FC8800931C32 /* GitHubAPIServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIServiceProtocol.swift; sourceTree = "<group>"; };
+		DAE8D9C22919FCB000931C32 /* GitHubAPIServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIServiceError.swift; sourceTree = "<group>"; };
+		DAE8D9C4291A3AB500931C32 /* GitHubAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +131,7 @@
 		BFD945DD244DC5E80012785A /* iOSEngineerCodeCheck */ = {
 			isa = PBXGroup;
 			children = (
+				DAE8D9AF2919F2ED00931C32 /* Service */,
 				DAE8D9A1291909D800931C32 /* Models */,
 				DACA2BD22917BDCE002989E0 /* ViewControllers */,
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
@@ -158,8 +177,40 @@
 				DAE8D9A62919538000931C32 /* SearchResponse.swift */,
 				DAE8D9A229191D0600931C32 /* Repository.swift */,
 				DAE8D9A82919574700931C32 /* User.swift */,
+				DAE8D9C4291A3AB500931C32 /* GitHubAPIError.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		DAE8D9AF2919F2ED00931C32 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				DAE8D9BD2919FC4A00931C32 /* GitHubAPIService */,
+				DAE8D9B42919F32000931C32 /* GitHubAPIRequest */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		DAE8D9B42919F32000931C32 /* GitHubAPIRequest */ = {
+			isa = PBXGroup;
+			children = (
+				DAE8D9B02919F2F500931C32 /* HTTPMethod.swift */,
+				DAE8D9B92919F38D00931C32 /* GitHubAPIRequestProtocol.swift */,
+				DAE8D9B52919F33B00931C32 /* GitHubAPIRequest.swift */,
+				DAE8D9B72919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift */,
+			);
+			path = GitHubAPIRequest;
+			sourceTree = "<group>";
+		};
+		DAE8D9BD2919FC4A00931C32 /* GitHubAPIService */ = {
+			isa = PBXGroup;
+			children = (
+				DAE8D9C22919FCB000931C32 /* GitHubAPIServiceError.swift */,
+				DAE8D9C02919FC8800931C32 /* GitHubAPIServiceProtocol.swift */,
+				DAE8D9BB2919FC4500931C32 /* GitHubAPIService.swift */,
+				DAE8D9BE2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift */,
+			);
+			path = GitHubAPIService;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -314,13 +365,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositoryListViewController.swift in Sources */,
+				DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
+				DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */,
 				DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */,
+				DAE8D9C5291A3AB500931C32 /* GitHubAPIError.swift in Sources */,
 				DAE8D9A329191D0600931C32 /* Repository.swift in Sources */,
+				DAE8D9B12919F2F500931C32 /* HTTPMethod.swift in Sources */,
+				DAE8D9BF2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift in Sources */,
+				DAE8D9BA2919F38D00931C32 /* GitHubAPIRequestProtocol.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				DAE8D9A92919574700931C32 /* User.swift in Sources */,
+				DAE8D9B82919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift in Sources */,
+				DAE8D9BC2919FC4500931C32 /* GitHubAPIService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck/Models/GitHubAPIError.swift
+++ b/iOSEngineerCodeCheck/Models/GitHubAPIError.swift
@@ -1,0 +1,20 @@
+//
+//  GitHubAPIError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+public struct GitHubAPIError: Decodable, Error {
+    public struct Error: Decodable {
+        public var resource: String
+        public var field: String
+        public var code: String
+    }
+
+    public var message: String  // レスポンスのJSONに必ず含まれる
+    public var errors: [Error]
+}

--- a/iOSEngineerCodeCheck/Models/Repository.swift
+++ b/iOSEngineerCodeCheck/Models/Repository.swift
@@ -1,0 +1,33 @@
+//
+//  Repository.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/07.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct Repository: Identifiable, Codable {
+    let id: Int
+    let name: String  // e.g. "Tetris"
+    let fullName: String  // e.g. "dtrupenn/Tetris"
+    let owner: User
+    let starsCount: Int
+    let watchersCount: Int
+    let forksCount: Int
+    let openIssuesCount: Int
+    let language: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case fullName = "full_name"
+        case owner
+        case starsCount = "stargazers_count"
+        case watchersCount = "watchers_count"
+        case forksCount = "forks_count"
+        case openIssuesCount = "open_issues_count"
+        case language
+    }
+}

--- a/iOSEngineerCodeCheck/Models/SearchResponse.swift
+++ b/iOSEngineerCodeCheck/Models/SearchResponse.swift
@@ -8,10 +8,9 @@
 
 import Foundation
 
-// TODO: itemsの型のジェネリクス化
-struct SearchResponse: Decodable {
+struct SearchResponse<Item: Decodable>: Decodable {
     let totalCount: Int
-    let items: [Repository]
+    let items: [Item]
 
     private enum CodingKeys: String, CodingKey {
         case totalCount = "total_count"

--- a/iOSEngineerCodeCheck/Models/SearchResponse.swift
+++ b/iOSEngineerCodeCheck/Models/SearchResponse.swift
@@ -1,0 +1,20 @@
+//
+//  SearchResponse.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/07.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+// TODO: itemsの型のジェネリクス化
+struct SearchResponse: Decodable {
+    let totalCount: Int
+    let items: [Repository]
+
+    private enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+        case items
+    }
+}

--- a/iOSEngineerCodeCheck/Models/User.swift
+++ b/iOSEngineerCodeCheck/Models/User.swift
@@ -1,0 +1,21 @@
+//
+//  User.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct User: Identifiable, Codable {
+    var id: Int
+    var name: String
+    var avatarImagePath: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name = "login"
+        case avatarImagePath = "avatar_url"
+    }
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
@@ -25,7 +25,7 @@ extension GitHubAPIRequest {
         }
 
         public var queryItems: [URLQueryItem] {
-            [URLQueryItem(name: "qqq", value: keyword)]
+            [URLQueryItem(name: "q", value: keyword)]
         }
 
         public var header: [String: String] {

--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
@@ -1,0 +1,40 @@
+//
+//  GitHubAPIRequest+SearchRepositories.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+extension GitHubAPIRequest {
+
+    public struct SearchRepositories: GitHubAPIRequestProtocol {
+        public let keyword: String
+        public typealias Response = SearchResponse<Repository>
+
+        // MARK: - Properties
+
+        public var method: HTTPMethod {
+            .get
+        }
+
+        public var path: String {
+            "/search/repositories"
+        }
+
+        public var queryItems: [URLQueryItem] {
+            [URLQueryItem(name: "qqq", value: keyword)]
+        }
+
+        public var header: [String: String] {
+            .init()
+        }
+
+        public var body: Data? {
+            nil
+        }
+    }
+
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest.swift
@@ -1,0 +1,13 @@
+//
+//  GitHubAPIRequest.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum GitHubAPIRequest {
+    // 実体はextensionで定義
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequestProtocol.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequestProtocol.swift
@@ -1,0 +1,53 @@
+//
+//  GitHubAPIRequestProtocol.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol GitHubAPIRequestProtocol {
+    associatedtype Response: Decodable
+
+    var baseURL: URL { get }
+    var path: String { get }  // baesURLからの相対パス
+    var method: HTTPMethod { get }
+    var queryItems: [URLQueryItem] { get }
+    var header: [String: String] { get }
+    var body: Data? { get }  // HTTP bodyに設定するパラメータ
+}
+
+extension GitHubAPIRequestProtocol {
+
+    var baseURL: URL {
+        guard let baseURL = URL(string: "https://api.github.com") else {
+            fatalError("リポジトリ検索用のURLの作成に失敗しました")
+        }
+        return baseURL
+    }
+
+    func buildURLRequest() -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        var urlRequest = URLRequest(url: url)
+
+        // クエリ・ヘッダの設定
+        components?.queryItems = queryItems  // クエリの追加
+        for (key, value) in header {
+            urlRequest.addValue(value, forHTTPHeaderField: key)
+        }
+
+        // ボディの設定
+        if let body = body {
+            urlRequest.httpBody = body
+        }
+
+        urlRequest.url = components?.url  // URLComponents型からURL型を取得。これにより適切なエンコードを施したクエリ文字列が付与される
+        urlRequest.httpMethod = method.rawValue
+
+        return urlRequest
+    }
+
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/HTTPMethod.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/HTTPMethod.swift
@@ -1,0 +1,21 @@
+//
+//  HTTPMethod.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+public enum HTTPMethod: String {
+    case get     = "GET"
+    case post    = "POST"
+    case put     = "PUT"
+    case head    = "HEAD"
+    case delete  = "DELETE"
+    case patch   = "PATCH"
+    case trace   = "TRACE"
+    case options = "OPTIONS"
+    case connect = "CONNECT"
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIService+SearchRepositories.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIService+SearchRepositories.swift
@@ -1,0 +1,22 @@
+//
+//  GitHubAPIService+SearchRepositories.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+extension GitHubAPIService {
+
+    final actor SearchRepositories: GitHubAPIServiceProtocol {
+
+        static let shared: SearchRepositories = .init()
+
+        func searchRepositories(keyword: String) async throws -> GitHubAPIRequest.SearchRepositories.Response {
+            let response = try await request(with: GitHubAPIRequest.SearchRepositories(keyword: keyword))
+            return response
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIService.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIService.swift
@@ -1,0 +1,13 @@
+//
+//  GitHubAPIService.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum GitHubAPIService {
+    // 実体は各extensionで定義
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceError.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceError.swift
@@ -1,0 +1,20 @@
+//
+//  GitHubAPIServiceError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum GitHubAPIServiceError: Error {
+    // 通信に失敗
+    case connectionError(Error)
+
+    // レスポンスの解釈に失敗
+    case responseParseError(Error)
+
+    // APIからエラーレスポンスを受け取った
+    case apiError(GitHubAPIError)
+}

--- a/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceProtocol.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceProtocol.swift
@@ -1,0 +1,57 @@
+//
+//  GitHubAPIServiceProtocol.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/08.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol GitHubAPIServiceProtocol {
+    func request<Request>(with request: Request) async throws ->
+    Request.Response where Request: GitHubAPIRequestProtocol
+}
+
+extension GitHubAPIServiceProtocol {
+    func request<Request>(with request: Request) async throws ->
+    Request.Response where Request: GitHubAPIRequestProtocol {
+
+        let (data, response): (Data, URLResponse)
+        do {
+            let urlRequest = request.buildURLRequest()
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw GitHubAPIServiceError.connectionError(error)
+        }
+
+        guard let statusCode = (response as? HTTPURLResponse)?.statusCode,
+              (200..<300).contains(statusCode) else {
+            // エラーレスポンス
+            #if DEBUG
+            let errorString = String(data: data, encoding: .utf8) ?? ""
+            print(errorString)
+            #endif
+
+            let gitHubAPIError: GitHubAPIError
+            do {
+                gitHubAPIError = try JSONDecoder().decode(GitHubAPIError.self, from: data)
+            } catch {
+                throw GitHubAPIServiceError.responseParseError(error)
+            }
+            throw GitHubAPIServiceError.apiError(gitHubAPIError)
+        }
+
+        // 成功レスポンス
+        #if DEBUG
+        let responseString = String(data: data, encoding: .utf8) ?? ""
+        print(responseString)
+        #endif
+        do {
+            let response = try JSONDecoder().decode(Request.Response.self, from: data)
+            return response
+        } catch {
+            throw GitHubAPIServiceError.responseParseError(error)
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/ViewControllers/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/ViewControllers/RepositoryDetailViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class RepositoryDetailViewController: UIViewController {
 
+    // MARK: - IBOutlet
+
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var languageLabel: UILabel!
@@ -18,11 +20,24 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet private weak var forksLabel: UILabel!
     @IBOutlet private weak var issuesLabel: UILabel!
 
-    var repositoryListViewController: RepositoryListViewController!
+    // MARK: - Properties
+
+    var repository: Repository?
+
+    // MARK: - LifeCycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let repository = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
+        configureUI()
+    }
+
+    // MARK: - Helpers
+
+    private func configureUI() {
+        guard let repository = repository else {
+            assertionFailure()
+            return
+        }
         starsLabel.text = "\(repository.starsCount) stars"
         watchersLabel.text = "\(repository.watchersCount) watchers"
         forksLabel.text = "\(repository.forksCount) forks"
@@ -36,7 +51,10 @@ class RepositoryDetailViewController: UIViewController {
     }
 
     func getImage() {
-        let repository = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
+        guard let repository = repository else {
+            assertionFailure()
+            return
+        }
         titleLabel.text = repository.fullName
         guard let avatarImageURL = URL(string: repository.owner.avatarImagePath) else {
             return

--- a/iOSEngineerCodeCheck/ViewControllers/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/ViewControllers/RepositoryDetailViewController.swift
@@ -22,39 +22,23 @@ class RepositoryDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let repo = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
-        // TODO: Repositoryの情報をModelに切り出し、JSONEncoderでデコード処理を行う
-        guard let starsCount = repo["stargazers_count"] as? Int,
-              let watchersCount = repo["watchers_count"] as? Int,
-              let forksCount = repo["forks_count"] as? Int,
-              let issuesCount = repo["open_issues_count"] as? Int
-        else {
-            fatalError("JSONパースエラー")
-        }
-        starsLabel.text = "\(starsCount) stars"
-        watchersLabel.text = "\(watchersCount) watchers"
-        forksLabel.text = "\(forksCount) forks"
-        issuesLabel.text = "\(issuesCount) open issues"
-
-        if let language = repo["language"] as? String {
+        let repository = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
+        starsLabel.text = "\(repository.starsCount) stars"
+        watchersLabel.text = "\(repository.watchersCount) watchers"
+        forksLabel.text = "\(repository.forksCount) forks"
+        issuesLabel.text = "\(repository.openIssuesCount) open issues"
+        if let language = repository.language {
             languageLabel.text = "Written in \(language)"
         } else {
             languageLabel.text = "(not specified language)"
         }
-
         getImage()
     }
 
     func getImage() {
-        let repo = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
-        if let title = repo["full_name"] as? String {
-            titleLabel.text = title
-        }
-
-        guard let owner = repo["owner"] as? [String: Any],
-              let avatarImagePath = owner["avatar_url"] as? String,
-              let avatarImageURL = URL(string: avatarImagePath)
-        else {
+        let repository = repositoryListViewController.repositories[repositoryListViewController.selectedRow]
+        titleLabel.text = repository.fullName
+        guard let avatarImageURL = URL(string: repository.owner.avatarImagePath) else {
             return
         }
         URLSession.shared.dataTask(with: avatarImageURL) { data, _, _ in

--- a/iOSEngineerCodeCheck/ViewControllers/RepositoryListViewController.swift
+++ b/iOSEngineerCodeCheck/ViewControllers/RepositoryListViewController.swift
@@ -64,7 +64,7 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
                 assertionFailure()
                 return
             }
-            detailViewController.repository = repositories[selectedRow]
+            detailViewController.viewModel = RepositoryDetailViewModel(repository: repositories[selectedRow])
         }
     }
 

--- a/iOSEngineerCodeCheck/ViewControllers/RepositoryListViewController.swift
+++ b/iOSEngineerCodeCheck/ViewControllers/RepositoryListViewController.swift
@@ -66,10 +66,13 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "Detail"{
-            guard let dtl = segue.destination as? RepositoryDetailViewController else {
+            guard let detailViewController = segue.destination as? RepositoryDetailViewController,
+                  selectedRow >= 0
+            else {
+                assertionFailure()
                 return
             }
-            dtl.repositoryListViewController = self
+            detailViewController.repository = repositories[selectedRow]
         }
     }
 

--- a/iOSEngineerCodeCheck/ViewModels/RepositoryDetailViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModels/RepositoryDetailViewModel.swift
@@ -1,0 +1,61 @@
+//
+//  RepositoryDetailViewModel.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/09.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct RepositoryDetailViewModel {
+
+    // MARK: - Properties
+
+    let repository: Repository
+
+    var titleText: String {
+        repository.fullName
+    }
+
+    var starsText: String {
+        "\(repository.starsCount) stars"
+    }
+
+    var watchersText: String {
+        "\(repository.watchersCount) watchers"
+    }
+
+    var forksText: String {
+        "\(repository.forksCount) forks"
+    }
+
+    var issuesText: String {
+        "\(repository.openIssuesCount) open issues"
+    }
+
+    var languageText: String {
+        if let language = repository.language {
+            return "Written in \(language)"
+        } else {
+            return "(not specified language)"
+        }
+    }
+
+    private var avatarImageURL: URL? {
+        URL(string: repository.owner.avatarImagePath)
+    }
+
+    // MARK: Functions
+
+    func downloadAvatarImage() async throws -> UIImage? {
+        guard let avatarImageURL = avatarImageURL else {
+            assertionFailure()
+            return nil
+        }
+        let (data, _) = try await URLSession.shared.data(from: avatarImageURL)
+        return UIImage(data: data)
+    }
+
+}


### PR DESCRIPTION
## Issue

- ref: [Fat VC の回避 \#8](https://github.com/pommdau/yumemi-inc-ios-engineer-codecheck/issues/8)

## Overview

- Fat ViewControllerの責務を別クラスへ切り出しを行いました
- 切り出しできる箇所がまだ残っていますが、変更量が多くなったため現時点で一旦PRします。

## Details (Optional)

- GitHubAPIの処理部分をServiceとして各クラスへ切り出しを行いました。
- リポジトリ詳細画面のUI情報の処理の責務をViewControllerからViewModelへ切り出しました。

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [x] Resolve Xcode warning

