### PR TITLE
Feature/replace storyboard to swiftui

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DAE8D9E2291C852100931C32 /* NameDescribable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9E1291C852100931C32 /* NameDescribable.swift */; };
 		DAE8D9EA291F828F00931C32 /* EngineerCodeCheckApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9E9291F828F00931C32 /* EngineerCodeCheckApp.swift */; };
 		DAE8D9EC291F82A400931C32 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9EB291F82A400931C32 /* ContentView.swift */; };
+		DAE8D9F22920ABB300931C32 /* RepositoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -98,6 +99,7 @@
 		DAE8D9E1291C852100931C32 /* NameDescribable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameDescribable.swift; sourceTree = "<group>"; };
 		DAE8D9E9291F828F00931C32 /* EngineerCodeCheckApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineerCodeCheckApp.swift; sourceTree = "<group>"; };
 		DAE8D9EB291F82A400931C32 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -271,6 +273,7 @@
 			children = (
 				DAE8D9DA291C81C300931C32 /* RepositoryListCell.swift */,
 				DAE8D9DE291C82F600931C32 /* RepositoryListCell.xib */,
+				DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -444,6 +447,7 @@
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */,
 				DAE8D9D8291BF17600931C32 /* ReusableCellIdentifier.swift in Sources */,
+				DAE8D9F22920ABB300931C32 /* RepositoryListView.swift in Sources */,
 				DAE8D9CF291B7B4100931C32 /* RepositoryListViewModel.swift in Sources */,
 				DAE8D9D2291B84FF00931C32 /* UIAlertController+showAlert.swift in Sources */,
 				DAE8D9DB291C81C300931C32 /* RepositoryListCell.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		DAE8D9DB291C81C300931C32 /* RepositoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9DA291C81C300931C32 /* RepositoryListCell.swift */; };
 		DAE8D9DF291C82F600931C32 /* RepositoryListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DAE8D9DE291C82F600931C32 /* RepositoryListCell.xib */; };
 		DAE8D9E2291C852100931C32 /* NameDescribable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9E1291C852100931C32 /* NameDescribable.swift */; };
+		DAE8D9EA291F828F00931C32 /* EngineerCodeCheckApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9E9291F828F00931C32 /* EngineerCodeCheckApp.swift */; };
+		DAE8D9EC291F82A400931C32 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9EB291F82A400931C32 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,6 +96,8 @@
 		DAE8D9DA291C81C300931C32 /* RepositoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListCell.swift; sourceTree = "<group>"; };
 		DAE8D9DE291C82F600931C32 /* RepositoryListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RepositoryListCell.xib; sourceTree = "<group>"; };
 		DAE8D9E1291C852100931C32 /* NameDescribable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameDescribable.swift; sourceTree = "<group>"; };
+		DAE8D9E9291F828F00931C32 /* EngineerCodeCheckApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineerCodeCheckApp.swift; sourceTree = "<group>"; };
+		DAE8D9EB291F82A400931C32 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +164,8 @@
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
 				BFD945EC244DC5EB0012785A /* Info.plist */,
+				DAE8D9E9291F828F00931C32 /* EngineerCodeCheckApp.swift */,
+				DAE8D9EB291F82A400931C32 /* ContentView.swift */,
 			);
 			path = iOSEngineerCodeCheck;
 			sourceTree = "<group>";
@@ -431,6 +437,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */,
+				DAE8D9EC291F82A400931C32 /* ContentView.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositoryListViewController.swift in Sources */,
 				DAE8D9CD291B32A700931C32 /* RepositoryDetailViewModel.swift in Sources */,
 				DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */,
@@ -448,6 +455,7 @@
 				DAE8D9BF2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift in Sources */,
 				DAE8D9BA2919F38D00931C32 /* GitHubAPIRequestProtocol.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				DAE8D9EA291F828F00931C32 /* EngineerCodeCheckApp.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				DAE8D9A92919574700931C32 /* User.swift in Sources */,
 				DAE8D9B82919F36000931C32 /* GitHubAPIRequest+SearchRepositories.swift in Sources */,

--- a/iOSEngineerCodeCheck/AppDelegate.swift
+++ b/iOSEngineerCodeCheck/AppDelegate.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication,

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -45,7 +45,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xer-fe-JeW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-498" y="137"/>
+            <point key="canvasLocation" x="-569" y="137"/>
         </scene>
         <!--Repository Detail View Controller-->
         <scene sceneID="JOC-74-7VT">

--- a/iOSEngineerCodeCheck/ContentView.swift
+++ b/iOSEngineerCodeCheck/ContentView.swift
@@ -10,9 +10,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Text("Hello, World!")
-        }
+        RepositoryListView()
     }
 }
 

--- a/iOSEngineerCodeCheck/ContentView.swift
+++ b/iOSEngineerCodeCheck/ContentView.swift
@@ -1,0 +1,23 @@
+//
+//  ContentView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/12.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Text("Hello, World!")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/iOSEngineerCodeCheck/EngineerCodeCheckApp.swift
+++ b/iOSEngineerCodeCheck/EngineerCodeCheckApp.swift
@@ -1,0 +1,18 @@
+//
+//  EngineerCodeCheckApp.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/12.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+@main
+struct EngineerCodeCheckApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Info.plist
+++ b/iOSEngineerCodeCheck/Info.plist
@@ -23,7 +23,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>
@@ -33,16 +33,12 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<string>LaunchScreen.storyboard</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/iOSEngineerCodeCheck/Views/RepositoryListView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListView.swift
@@ -1,0 +1,46 @@
+//
+//  RepositoryListView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/13.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct RepositoryListView: View {
+
+    @State private var repositories = ["repo1", "repo2", "repo3"]
+    @State private var keyword = ""
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(repositories, id: \.self) { repository in
+                    NavigationLink {
+                        Text(repository)
+                    } label: {
+                        HStack {
+                            Text("<user>/\(repository)")
+                            Spacer()
+                            Text("<language>")
+                        }
+                    }
+                }
+            }
+        }
+        .searchable(text: $keyword,
+                    placement: .automatic,
+                    prompt: "GitHubのリポジトリを検索") {
+        }
+        .onSubmit(of: .search) {
+            repositories.append("new result")
+        }
+    }
+}
+
+struct RepositoryListView_Previews: PreviewProvider {
+    static var previews: some View {
+        RepositoryListView()
+    }
+}


### PR DESCRIPTION
## Issue

- ref [UI をブラッシュアップ \#14](https://github.com/pommdau/yumemi-inc-ios-engineer-codecheck/issues/14)

## Overview

- StoryboardのSwiftUIへの置き換え

## Details (Optional)

- 起動時に表示する画面をStoryboardからSwiftUIに置き換えました。
- 現状モック画面の表示としているため、mainに含められる内容になるまで一時的にDevelopを切って運用しています。

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [x] Resolve Xcode warning

## Screenshots
- 現在はモック画面の表示となっています。

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/201507601-9757af06-725a-4efa-b533-a3fd044b601a.png">

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/201507604-b53cab38-ebdd-46aa-aadb-bec0817acfb3.png">
