### PR TITLE
リポジトリ検索画面・詳細画面のUI改善

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD945F6244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift */; };
 		BFD94601244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift */; };
+		DA1F8B9629213ED9002B286C /* RepositoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */; };
 		DAE8D9A329191D0600931C32 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A229191D0600931C32 /* Repository.swift */; };
 		DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A62919538000931C32 /* SearchResponse.swift */; };
 		DAE8D9A92919574700931C32 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A82919574700931C32 /* User.swift */; };
@@ -67,6 +68,7 @@
 		BFD945FC244DC5EB0012785A /* iOSEngineerCodeCheckUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSEngineerCodeCheckUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD94600244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSEngineerCodeCheckUITests.swift; sourceTree = "<group>"; };
 		BFD94602244DC5EC0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListCell.swift; sourceTree = "<group>"; };
 		DAA00AEA2914FABD00EB1481 /* README_Git.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Git.md; sourceTree = "<group>"; };
 		DAA00AEB2915009100EB1481 /* README_SwiftLint.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_SwiftLint.md; sourceTree = "<group>"; };
 		DAA00AED291500F700EB1481 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */,
+				DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */,
 				DAEE4CC629211D2E00123CB9 /* RepositoryDetailView.swift */,
 			);
 			path = Views;
@@ -431,6 +434,7 @@
 				DAE8D9A329191D0600931C32 /* Repository.swift in Sources */,
 				DAE8D9B12919F2F500931C32 /* HTTPMethod.swift in Sources */,
 				DAE8D9D6291BF03A00931C32 /* SegueIdentifier.swift in Sources */,
+				DA1F8B9629213ED9002B286C /* RepositoryListCell.swift in Sources */,
 				DAE8D9BF2919FC6B00931C32 /* GitHubAPIService+SearchRepositories.swift in Sources */,
 				DAE8D9BA2919F38D00931C32 /* GitHubAPIRequestProtocol.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
@@ -13,50 +13,66 @@ struct RepositoryDetailView: View {
     let repository: Repository
 
     var body: some View {
-        HStack {
+
+        VStack(alignment: .leading) {
+            HStack {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 28))
+                Text(repository.fullName)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(repository.name)
+                .font(.title2)
+                .bold()
+                .padding(.vertical, 2)
+
+            Text("<description>")
+
+            Grid {
+                GridRow {
+                    Image(systemName: "star")
+                        .foregroundColor(.secondary)
+                        .gridColumnAlignment(.center)
+                    Text("\(repository.starsCount)")
+                        .bold()
+                        .gridColumnAlignment(.trailing)
+                    Text("stars")
+                        .foregroundColor(.secondary)
+                        .gridColumnAlignment(.leading)
+                }
+                GridRow {
+                    Image(systemName: "eye")
+                        .foregroundColor(.secondary)
+                    Text("\(repository.watchersCount)")
+                        .bold()
+                    Text("watching")
+                        .foregroundColor(.secondary)
+                }
+                GridRow {
+                    Image(systemName: "arrow.triangle.branch")
+                        .foregroundColor(.secondary)
+                    Text("\(repository.forksCount)")
+                        .bold()
+                    Text("forks")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.vertical)
+
+            Divider()
+
             VStack(alignment: .leading) {
-                HStack {
-                    Image(systemName: "person.fill")
-                        .font(.system(size: 40))
-                    Text(repository.fullName)
-                }
-                .padding(.bottom, 20)
-
-                Text("About")
-                    .font(.title2)
-
-                Text("<description>")
-
-                Grid {
-                    GridRow {
-                        Image(systemName: "star")
-                            .gridColumnAlignment(.center)
-                        Text("\(repository.starsCount)")
-                            .gridColumnAlignment(.trailing)
-                        Text("stars")
-                            .gridColumnAlignment(.leading)
-                    }
-                    GridRow {
-                        Image(systemName: "eye")
-                        Text("\(repository.watchersCount)")
-                        Text("watching")
-                    }
-                    GridRow {
-                        Image(systemName: "arrow.triangle.branch")
-                        Text("\(repository.forksCount)")
-                        Text("forks")
-                    }
-                }
-                .padding(.vertical)
-
-                Divider()
-
                 Text("Languages")
                     .font(.title2)
-                Text(repository.language ?? "")
-
-                Spacer()
+                HStack(spacing: 8) {
+                    Circle()
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(.red)
+                    Text(repository.language ?? "")
+                }
             }
+
             Spacer()
         }
         .padding()

--- a/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct RepositoryDetailView: View {
 
-    let repositoty: Repository
+    let repository: Repository
 
     var body: some View {
         HStack {
@@ -18,7 +18,7 @@ struct RepositoryDetailView: View {
                 HStack {
                     Image(systemName: "person.fill")
                         .font(.system(size: 40))
-                    Text(repositoty.fullName)
+                    Text(repository.fullName)
                 }
                 .padding(.bottom, 20)
 
@@ -31,19 +31,19 @@ struct RepositoryDetailView: View {
                     GridRow {
                         Image(systemName: "star")
                             .gridColumnAlignment(.center)
-                        Text("\(repositoty.starsCount)")
+                        Text("\(repository.starsCount)")
                             .gridColumnAlignment(.trailing)
                         Text("stars")
                             .gridColumnAlignment(.leading)
                     }
                     GridRow {
                         Image(systemName: "eye")
-                        Text("\(repositoty.watchersCount)")
+                        Text("\(repository.watchersCount)")
                         Text("watching")
                     }
                     GridRow {
                         Image(systemName: "arrow.triangle.branch")
-                        Text("\(repositoty.forksCount)")
+                        Text("\(repository.forksCount)")
                         Text("forks")
                     }
                 }
@@ -53,7 +53,7 @@ struct RepositoryDetailView: View {
 
                 Text("Languages")
                     .font(.title2)
-                Text(repositoty.language ?? "")
+                Text(repository.language ?? "")
 
                 Spacer()
             }
@@ -68,6 +68,6 @@ struct RepositoryDetailView_Previews: PreviewProvider {
     @State static var repository = Repository.sampleData[0]
 
     static var previews: some View {
-        RepositoryDetailView(repositoty: repository)
+        RepositoryDetailView(repository: repository)
     }
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
@@ -1,0 +1,60 @@
+//
+//  RepositoryListCell.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/14.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct RepositoryListCell: View {
+
+    let repository: Repository
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 24))
+                Text(repository.owner.name)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(repository.name)
+                .font(.title2)
+                .bold()
+                .padding(.vertical, 2)
+
+            Text("<description>")
+
+            HStack {
+                HStack(spacing: 4) {
+                    Image(systemName: "star")
+                    Text("\(repository.starsCount)")
+                }
+                .foregroundColor(.secondary)
+
+                HStack(spacing: 4) {
+                    Circle()
+                        .frame(width: 18, height: 18)
+                        .foregroundColor(.red)
+                    Text(repository.language ?? "")
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+}
+
+struct RepositoryListCell_Previews: PreviewProvider {
+    static var previews: some View {
+        RepositoryListCell(repository: Repository.sampleData[0])
+            .previewLayout(.fixed(width: 400, height: 400))
+            .padding()
+        
+        RepositoryListCell(repository: Repository.sampleData[1])
+            .previewLayout(.fixed(width: 400, height: 400))
+            .padding()
+    }
+}

--- a/iOSEngineerCodeCheck/Views/RepositoryListView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListView.swift
@@ -24,10 +24,12 @@ struct RepositoryListView: View {
                     }
                 }
             }
+            .navigationTitle("GitHubリポジトリの検索")
+            .navigationBarTitleDisplayMode(.inline)
         }
         .searchable(text: $keyword,
                     placement: .automatic,
-                    prompt: "GitHubのリポジトリを検索") {
+                    prompt: "検索") {
         }
         .onSubmit(of: .search) {
             Task {

--- a/iOSEngineerCodeCheck/Views/RepositoryListView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListView.swift
@@ -18,13 +18,9 @@ struct RepositoryListView: View {
             List {
                 ForEach(viewModel.repositories) { repository in
                     NavigationLink {
-                        RepositoryDetailView(repositoty: repository)
+                        RepositoryDetailView(repository: repository)
                     } label: {
-                        HStack {
-                            Text(repository.fullName)
-                            Spacer()
-                            Text(repository.language ?? "")
-                        }
+                        RepositoryListCell(repository: repository)
                     }
                 }
             }


### PR DESCRIPTION
## Issue

- ref [UI をブラッシュアップ \#14](https://github.com/pommdau/yumemi-inc-ios-engineer-codecheck/issues/14)

## Overview

- リポジトリ検索画面・詳細画面のUIを改善しました。
  - ただしいくつかの情報は現状モックとなっています。

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [x] Resolve Xcode warning

## Screenshot

<img width="559" alt="image" src="https://user-images.githubusercontent.com/29433103/201562390-c7413225-8119-426b-92bd-427def21eaf7.png">

<img width="689" alt="image" src="https://user-images.githubusercontent.com/29433103/201562360-e1f6fd95-63c7-4867-a86d-8f7745dcc77f.png">

