### PR TITLE
検索前後の画面の実装

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		BFD945F6244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* IOSEngineerCodeCheckTests.swift */; };
 		BFD94601244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift */; };
 		DA1F8B9629213ED9002B286C /* RepositoryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */; };
+		DA2505AB2922136000C31B70 /* Stateful.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2505AA2922136000C31B70 /* Stateful.swift */; };
+		DA2505B42922235200C31B70 /* MessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2505B32922235200C31B70 /* MessageError.swift */; };
 		DAE8D9A329191D0600931C32 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A229191D0600931C32 /* Repository.swift */; };
 		DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A62919538000931C32 /* SearchResponse.swift */; };
 		DAE8D9A92919574700931C32 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A82919574700931C32 /* User.swift */; };
@@ -69,6 +71,8 @@
 		BFD94600244DC5EC0012785A /* IOSEngineerCodeCheckUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSEngineerCodeCheckUITests.swift; sourceTree = "<group>"; };
 		BFD94602244DC5EC0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListCell.swift; sourceTree = "<group>"; };
+		DA2505AA2922136000C31B70 /* Stateful.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stateful.swift; sourceTree = "<group>"; };
+		DA2505B32922235200C31B70 /* MessageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageError.swift; sourceTree = "<group>"; };
 		DAA00AEA2914FABD00EB1481 /* README_Git.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_Git.md; sourceTree = "<group>"; };
 		DAA00AEB2915009100EB1481 /* README_SwiftLint.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README_SwiftLint.md; sourceTree = "<group>"; };
 		DAA00AED291500F700EB1481 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -182,6 +186,13 @@
 			path = iOSEngineerCodeCheckUITests;
 			sourceTree = "<group>";
 		};
+		DA2505B229221B9D00C31B70 /* RepositoryListView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = RepositoryListView;
+			sourceTree = "<group>";
+		};
 		DAE8D9AF2919F2ED00931C32 /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -254,8 +265,9 @@
 		DAE8D9D9291C815100931C32 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */,
+				DA2505B229221B9D00C31B70 /* RepositoryListView */,
 				DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */,
+				DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */,
 				DAEE4CC629211D2E00123CB9 /* RepositoryDetailView.swift */,
 			);
 			path = Views;
@@ -265,6 +277,8 @@
 			isa = PBXGroup;
 			children = (
 				DAE8D9E1291C852100931C32 /* NameDescribable.swift */,
+				DA2505AA2922136000C31B70 /* Stateful.swift */,
+				DA2505B32922235200C31B70 /* MessageError.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -423,6 +437,7 @@
 				DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */,
 				DAE8D9EC291F82A400931C32 /* ContentView.swift in Sources */,
 				DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */,
+				DA2505AB2922136000C31B70 /* Stateful.swift in Sources */,
 				DAEE4CC729211D2E00123CB9 /* RepositoryDetailView.swift in Sources */,
 				DAE8D9C12919FC8800931C32 /* GitHubAPIServiceProtocol.swift in Sources */,
 				DAE8D9D8291BF17600931C32 /* ReusableCellIdentifier.swift in Sources */,
@@ -430,6 +445,7 @@
 				DAE8D9CF291B7B4100931C32 /* RepositoryListViewModel.swift in Sources */,
 				DAE8D9D2291B84FF00931C32 /* UIAlertController+showAlert.swift in Sources */,
 				DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */,
+				DA2505B42922235200C31B70 /* MessageError.swift in Sources */,
 				DAE8D9C5291A3AB500931C32 /* GitHubAPIError.swift in Sources */,
 				DAE8D9A329191D0600931C32 /* Repository.swift in Sources */,
 				DAE8D9B12919F2F500931C32 /* HTTPMethod.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -186,13 +186,6 @@
 			path = iOSEngineerCodeCheckUITests;
 			sourceTree = "<group>";
 		};
-		DA2505B229221B9D00C31B70 /* RepositoryListView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = RepositoryListView;
-			sourceTree = "<group>";
-		};
 		DAE8D9AF2919F2ED00931C32 /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -265,7 +258,6 @@
 		DAE8D9D9291C815100931C32 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				DA2505B229221B9D00C31B70 /* RepositoryListView */,
 				DA1F8B9529213ED9002B286C /* RepositoryListCell.swift */,
 				DAE8D9F12920ABB300931C32 /* RepositoryListView.swift */,
 				DAEE4CC629211D2E00123CB9 /* RepositoryDetailView.swift */,

--- a/iOSEngineerCodeCheck/Utils/MessageError.swift
+++ b/iOSEngineerCodeCheck/Utils/MessageError.swift
@@ -1,0 +1,14 @@
+//
+//  MessageError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/14.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+// ref: https://ikeh1024.hatenablog.com/entry/2022/11/14/155956
+struct MessageError: Swift.Error, CustomStringConvertible {
+    var description: String
+}

--- a/iOSEngineerCodeCheck/Utils/Stateful.swift
+++ b/iOSEngineerCodeCheck/Utils/Stateful.swift
@@ -1,0 +1,16 @@
+//
+//  Stateful.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2022/11/14.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum Stateful<Value> {
+    case idle // まだデータを取得しにいっていない
+    case loading // 読み込み中
+    case failed(Error) // 読み込み失敗、遭遇したエラーを保持
+    case loaded(Value) // 読み込み完了、読み込まれたデータを保持
+}

--- a/iOSEngineerCodeCheck/ViewModels/RepositoryListViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModels/RepositoryListViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 @MainActor
 final class RepositoryListViewModel: ObservableObject {
-    @Published private(set) var repositories: [Repository] = Repository.sampleData
+    @Published private(set) var repositories: Stateful<[Repository]> = .idle
     private var task: URLSessionTask?
 }
 
@@ -26,8 +26,12 @@ extension RepositoryListViewModel {
         guard !keyword.isEmpty else {
             return
         }
-        let response = try await GitHubAPIService.SearchRepositories.shared.searchRepositories(keyword: keyword)
-        repositories = response.items
+        repositories = .loading
+        do {
+            let response = try await GitHubAPIService.SearchRepositories.shared.searchRepositories(keyword: keyword)
+            repositories = .loaded(response.items)
+        } catch {
+            repositories = .failed(error)
+        }
     }
-
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
@@ -27,8 +27,6 @@ struct RepositoryDetailView: View {
                 .bold()
                 .padding(.vertical, 2)
 
-            Text("<description>")
-
             Grid {
                 GridRow {
                     Image(systemName: "star")

--- a/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
@@ -52,7 +52,7 @@ struct RepositoryListCell_Previews: PreviewProvider {
         RepositoryListCell(repository: Repository.sampleData[0])
             .previewLayout(.fixed(width: 400, height: 400))
             .padding()
-        
+
         RepositoryListCell(repository: Repository.sampleData[1])
             .previewLayout(.fixed(width: 400, height: 400))
             .padding()

--- a/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
@@ -14,35 +14,51 @@ struct RepositoryListCell: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            HStack {
-                Image(systemName: "person.fill")
-                    .font(.system(size: 24))
-                Text(repository.owner.name)
-                    .foregroundColor(.secondary)
-            }
+            userLabel()
 
             Text(repository.name)
                 .font(.title2)
                 .bold()
                 .padding(.vertical, 2)
 
-            Text("<description>")
-
-            HStack {
-                HStack(spacing: 4) {
-                    Image(systemName: "star")
-                    Text("\(repository.starsCount)")
-                }
-                .foregroundColor(.secondary)
-
-                HStack(spacing: 4) {
-                    Circle()
-                        .frame(width: 18, height: 18)
-                        .foregroundColor(.red)
-                    Text(repository.language ?? "")
-                        .foregroundColor(.secondary)
+            HStack(spacing: 18) {
+                starsLabel()
+                if (repository.language?.isEmpty) != nil {
+                    languageLabel()
                 }
             }
+        }
+    }
+
+    // MARK: - ViewBuilder
+
+    @ViewBuilder
+    private func userLabel() -> some View {
+        HStack {
+            Image(systemName: "person.fill")
+                .font(.system(size: 24))
+            Text(repository.owner.name)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func starsLabel() -> some View {
+        HStack(spacing: 2) {
+            Image(systemName: "star")
+            Text("\(repository.starsCount)")
+        }
+        .foregroundColor(.secondary)
+    }
+
+    @ViewBuilder
+    private func languageLabel() -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .frame(width: 12, height: 12)
+                .foregroundColor(.red)
+            Text(repository.language ?? "")
+                .foregroundColor(.secondary)
         }
     }
 }


### PR DESCRIPTION
## Issue

- ref [UI をブラッシュアップ \#14](https://github.com/pommdau/yumemi-inc-ios-engineer-codecheck/issues/14)

## Overview

- 検索前後の画面の実装を行いました。

## Details (Optional)

- 検索前・検索中・結果の表示・検索の失敗のビューをそれぞれ実装。
- リポジトリデータの持ち方を、データから状態に変更しました。

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [ ] Resolve Xcode warning

## Screenshots

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/201601950-ad1694b3-e5d9-44e7-9ce5-f09bcbe2519b.png">

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/201601983-c1aa6c2c-6c30-4042-8e0e-cda80e5a8b05.png">

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/201602000-904b3b04-dbba-4003-84fe-cf26a14ee3f3.png">

<img width="326" alt="image" src="https://user-images.githubusercontent.com/29433103/201602104-e5296f5a-11cb-4804-b792-596c624e238a.png">



