### PR TITLE
リポジトリ詳細画面のUI改善

### DIFF
--- a/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIRequest/GitHubAPIRequest+SearchRepositories.swift
@@ -29,7 +29,7 @@ extension GitHubAPIRequest {
         }
 
         public var header: [String: String] {
-            .init()
+            ["Accept": "application/vnd.github.v3+json"]
         }
 
         public var body: Data? {

--- a/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceProtocol.swift
+++ b/iOSEngineerCodeCheck/Service/GitHubAPIService/GitHubAPIServiceProtocol.swift
@@ -44,8 +44,8 @@ extension GitHubAPIServiceProtocol {
 
         // 成功レスポンス
         #if DEBUG
-        //        let responseString = String(data: data, encoding: .utf8) ?? ""
-        //        print(responseString)
+//        let responseString = String(data: data, encoding: .utf8) ?? ""
+//        print(responseString)
         #endif
         do {
             let response = try JSONDecoder().decode(Request.Response.self, from: data)

--- a/iOSEngineerCodeCheck/Service/Models/Repository+sampleData.swift
+++ b/iOSEngineerCodeCheck/Service/Models/Repository+sampleData.swift
@@ -17,26 +17,33 @@ extension Repository {
               owner:
                 User(id: 10639145,
                      name: "apple",
-                     avatarImagePath: "https://avatars.githubusercontent.com/u/10639145?v=4"),
+                     avatarImagePath: "https://avatars.githubusercontent.com/u/10639145?v=4",
+                     htmlPath: "https://github.com/apple"),
               starsCount: 61080,
               watchersCount: 2100,
               forksCount: 9815,
               openIssuesCount: 6175,
               language: "C++",
+              htmlPath: "https://github.com/apple/swift",
+              website: "https://www.swift.org/",
               description: "The Swift Programming Language",
               subscribersCount: 2508),
         .init(id: 20682114,
-              name: "SwiftLanguageWeather",
+              name: "SwiftLanguageWeather_longlonglonglonglonglonglonglong",
               fullName: "JakeLin/SwiftLanguageWeather",
               owner:
                 User(id: 573856,
-                     name: "JakeLin",
-                     avatarImagePath: "https://avatars.githubusercontent.com/u/573856?v=4"),
+                     name: "JakeLin_longlonglonglonglonglonglonglong",
+                     avatarImagePath: "https://avatars.githubusercontent.com/u/573856?v=4",
+                     htmlPath: "https://github.com/apple"),
               starsCount: 5202,
               watchersCount: 300,
               forksCount: 1220,
               openIssuesCount: 9,
-              language: "Swift")
+              language: "Swift",
+              htmlPath: "https://github.com/JakeLin/SwiftLanguageWeather",
+              website: nil,
+              description: nil)
     ]
 
 }

--- a/iOSEngineerCodeCheck/Service/Models/Repository.swift
+++ b/iOSEngineerCodeCheck/Service/Models/Repository.swift
@@ -19,9 +19,11 @@ struct Repository: Identifiable, Codable {
     let forksCount: Int
     let openIssuesCount: Int
     let language: String?
+    let htmlPath: String  // リポジトリのURL
+    let website: String?  // 設定したホームページ
+    let description: String?
     
     // その他補完されて取得される情報
-    var description: String?
     var subscribersCount: Int?
 
     private enum CodingKeys: String, CodingKey {
@@ -34,10 +36,12 @@ struct Repository: Identifiable, Codable {
         case forksCount = "forks_count"
         case openIssuesCount = "open_issues_count"
         case language
+        case htmlPath = "html_url"
+        case website = "homepage"
+        case description
     }
     
     mutating func update(withRepositoryDetail detail: RepositoryDetail) {
-        self.description = detail.description
         self.subscribersCount = detail.subscribersCount
     }
 }

--- a/iOSEngineerCodeCheck/Service/Models/User.swift
+++ b/iOSEngineerCodeCheck/Service/Models/User.swift
@@ -12,10 +12,12 @@ struct User: Identifiable, Codable {
     var id: Int
     var name: String
     var avatarImagePath: String
+    let htmlPath: String  // e.g. https://github.com/apple
 
     private enum CodingKeys: String, CodingKey {
         case id
         case name = "login"
         case avatarImagePath = "avatar_url"
+        case htmlPath = "html_url"
     }
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
@@ -110,6 +110,23 @@ struct RepositoryDetailView: View {
                     Text("issues")
                         .foregroundColor(.secondary)
                 }
+                
+                if let website = repository.website {
+                    GridRow {
+                        Image(systemName: "link")
+                            .foregroundColor(.secondary)
+                        Button {
+                            guard let url = URL(string: website) else {
+                                return
+                            }
+                            UIApplication.shared.open(url)
+                        } label: {
+                            Text("\(website)")
+                                .bold()
+                        }
+                        .gridCellColumns(3)
+                    }
+                }
             }
         }
     }
@@ -136,8 +153,8 @@ struct RepositoryDetailView_Previews: PreviewProvider {
 
     static var previews: some View {
         Group {
-            RepositoryDetailView(repository: Repository.sampleData[1])
             RepositoryDetailView(repository: Repository.sampleData[0])
+            RepositoryDetailView(repository: Repository.sampleData[1])
         }
     }
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryDetailView.swift
@@ -16,21 +16,62 @@ struct RepositoryDetailView: View {
     var body: some View {
 
         VStack(alignment: .leading) {
-            HStack {
-                WebImage(url: URL(string: repository.owner.avatarImagePath))
-                    .resizable()
-                    .placeholder(Image(systemName: "person.fill"))
-                    .frame(maxWidth: 60, maxHeight: 60)
+            titleSection(repository: repository)
+            Divider()
+            aboutSection(repository: repository)
+            Divider()
+            languageSection(language: repository.language)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+    }
+        
+    @ViewBuilder
+    private func titleSection(repository: Repository) -> some View {
+        HStack(spacing: 8) {
+            WebImage(url: URL(string: repository.owner.avatarImagePath))
+                .resizable()
+                .placeholder(Image(systemName: "person.fill"))
+                .frame(maxWidth: 40, maxHeight: 40)
+                .cornerRadius(20)
+            
+            Button {
+                guard let url = URL(string: repository.owner.htmlPath) else {
+                    return
+                }
+                UIApplication.shared.open(url)
+            } label: {
                 Text(repository.owner.name)
+                    .lineLimit(1)
                     .font(.title2)
-                    .foregroundColor(.secondary)
             }
-
-            Text(repository.name)
-                .font(.title)
+            Text("/")
+            Button {
+                guard let url = URL(string: repository.htmlPath) else {
+                    return
+                }
+                UIApplication.shared.open(url)
+            } label: {
+                Text(repository.name)
+                    .lineLimit(1)
+                    .font(.title2)
+                    .bold()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private func aboutSection(repository: Repository) -> some View {
+        VStack(alignment: .leading) {
+            Text("About")
+                .font(.title2)
                 .bold()
-                .padding(.vertical, 2)
-
+                .padding(.vertical)
+            if let description = repository.description,
+               !description.isEmpty {
+                Text(repository.description ?? "(description)")
+                    .padding(.bottom, 8)
+            }
             Grid(verticalSpacing: 8) {
                 GridRow {
                     Image(systemName: "star")
@@ -43,6 +84,7 @@ struct RepositoryDetailView: View {
                         .foregroundColor(.secondary)
                         .gridColumnAlignment(.leading)
                 }
+                /*
                 GridRow {
                     Image(systemName: "eye")
                         .foregroundColor(.secondary)
@@ -51,6 +93,7 @@ struct RepositoryDetailView: View {
                     Text("watching")
                         .foregroundColor(.secondary)
                 }
+                 */
                 GridRow {
                     Image(systemName: "arrow.triangle.branch")
                         .foregroundColor(.secondary)
@@ -59,33 +102,42 @@ struct RepositoryDetailView: View {
                     Text("forks")
                         .foregroundColor(.secondary)
                 }
+                GridRow {
+                    Image(systemName: "circle.circle")
+                        .foregroundColor(.secondary)
+                    Text("\(repository.openIssuesCount)")
+                        .bold()
+                    Text("issues")
+                        .foregroundColor(.secondary)
+                }
             }
-            .padding(.vertical)
-
-            Divider()
-
+        }
+    }
+    
+    @ViewBuilder
+    private func languageSection(language: String?) -> some View {
+        if let language, !language.isEmpty {
             VStack(alignment: .leading) {
-                Text("Languages")
+                Text("Language")
                     .font(.title2)
+                    .bold()
                 HStack(spacing: 8) {
                     Circle()
                         .frame(width: 14, height: 14)
-                        .foregroundColor(GitHubLanguageColor.shared.getColor(withName: repository.language))
+                        .foregroundColor(GitHubLanguageColor.shared.getColor(withName: language))
                     Text(repository.language ?? "")
                 }
             }
-
-            Spacer()
         }
-        .padding()
     }
 }
 
 struct RepositoryDetailView_Previews: PreviewProvider {
 
-    @State static var repository = Repository.sampleData[0]
-
     static var previews: some View {
-        RepositoryDetailView(repository: repository)
+        Group {
+            RepositoryDetailView(repository: Repository.sampleData[1])
+            RepositoryDetailView(repository: Repository.sampleData[0])
+        }
     }
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListCell.swift
@@ -38,8 +38,10 @@ struct RepositoryListCell: View {
                 .resizable()
                 .placeholder(Image(systemName: "person.fill"))
                 .frame(width: 24, height: 24)
+                .cornerRadius(12)
             Text(userName)
                 .foregroundColor(.secondary)
+                .lineLimit(1)
         }
     }
     
@@ -77,12 +79,15 @@ struct RepositoryListCell: View {
 
 struct RepositoryListCell_Previews: PreviewProvider {
     static var previews: some View {
-        RepositoryListCell(repository: Repository.sampleData[0])
-            .previewLayout(.fixed(width: 400, height: 400))
-            .padding()
-
-        RepositoryListCell(repository: Repository.sampleData[1])
-            .previewLayout(.fixed(width: 400, height: 400))
-            .padding()
+        
+        Group {
+            RepositoryListCell(repository: Repository.sampleData[0])
+                .previewLayout(.fixed(width: 200, height: 400))
+                .padding()
+            
+            RepositoryListCell(repository: Repository.sampleData[1])
+                .previewLayout(.fixed(width: 200, height: 400))
+                .padding()
+        }
     }
 }

--- a/iOSEngineerCodeCheck/Views/RepositoryListView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositoryListView.swift
@@ -18,7 +18,6 @@ struct RepositoryListView: View {
             // 上記が.searchableと同じクラスでは使えず子Viewでしか使えないためクラスを分割している
             // TODO: ViewModelを複数クラスで使用するのは行儀の良くない気がする…
             RepositoryListSearchResultView(viewModel: viewModel)
-                .navigationTitle("GitHubリポジトリ検索")
                 .navigationBarTitleDisplayMode(.inline)
                 .searchable(text: $viewModel.keyword,
                             placement: .automatic,


### PR DESCRIPTION
## Issue

- ref: [UI をブラッシュアップ \#14](https://github.com/pommdau/yumemi-inc-ios-engineer-codecheck/issues/14)

## Overview

- リポジトリ詳細画面のUI改善を行いました

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [ ] Resolve Xcode warning

## ScreenShots

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/202464762-327b9c6a-72a8-4f05-b580-6c2c8e019fe5.png">

<img width="514" alt="image" src="https://user-images.githubusercontent.com/29433103/202464815-8037f342-5653-495b-899d-428e81787b1b.png">
