### PR TITLE
検索の履歴や候補を表示するように改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@
 
 | 検索前 | 検索中 | 検索後 | 詳細画面 |
 |---|---|---|---|
-| ![Screen Shot 2023-01-06 at 22.25.41](https://i.imgur.com/0QFNKWV.png) | ![Screen Shot 2023-01-06 at 22.25.22](https://i.imgur.com/pru4Nnf.png) | ![Screen Shot 2023-01-06 at 22.25.34](https://i.imgur.com/YigKDIi.png) | ![ScreenShot](https://i.imgur.com/YMxZBVp.png) |
+|---|---|---|---|
 
-https://user-images.githubusercontent.com/29433103/211025910-5a224cf9-5251-4d15-8349-b25ff0863c95.mp4
+https://github.com/user-attachments/assets/3e26fc78-ad01-434c-b901-750513873b4d

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		DAC7078B2937E25E00E56F95 /* ReadyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC7078A2937E25E00E56F95 /* ReadyView.swift */; };
 		DAC7078F2937E2B800E56F95 /* FailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC7078E2937E2B800E56F95 /* FailedView.swift */; };
 		DAC707912937E38A00E56F95 /* RepositoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC707902937E38A00E56F95 /* RepositoryList.swift */; };
+		DAD2178A2CB7CB1F004A6E78 /* Array+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD217892CB7CB1F004A6E78 /* Array+RawRepresentable.swift */; };
+		DAD2178C2CB7CCC0004A6E78 /* SearchSuggestionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD2178B2CB7CCC0004A6E78 /* SearchSuggestionManager.swift */; };
 		DAE8D9A329191D0600931C32 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A229191D0600931C32 /* Repository.swift */; };
 		DAE8D9A72919538000931C32 /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A62919538000931C32 /* SearchResponse.swift */; };
 		DAE8D9A92919574700931C32 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE8D9A82919574700931C32 /* User.swift */; };
@@ -146,6 +148,8 @@
 		DAC7078A2937E25E00E56F95 /* ReadyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyView.swift; sourceTree = "<group>"; };
 		DAC7078E2937E2B800E56F95 /* FailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedView.swift; sourceTree = "<group>"; };
 		DAC707902937E38A00E56F95 /* RepositoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryList.swift; sourceTree = "<group>"; };
+		DAD217892CB7CB1F004A6E78 /* Array+RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+RawRepresentable.swift"; sourceTree = "<group>"; };
+		DAD2178B2CB7CCC0004A6E78 /* SearchSuggestionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSuggestionManager.swift; sourceTree = "<group>"; };
 		DAE8D9A229191D0600931C32 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		DAE8D9A62919538000931C32 /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
 		DAE8D9A82919574700931C32 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -232,6 +236,7 @@
 				DA34FD812942F48500EFB647 /* ViewInspector */,
 				DAE8D9E0291C851500931C32 /* Utils */,
 				DAE8D9AF2919F2ED00931C32 /* Service */,
+				DAD2178D2CB7D3E7004A6E78 /* Controllers */,
 				DAE8D9D9291C815100931C32 /* Views */,
 				DAE8D9CB291AA36C00931C32 /* ViewModels */,
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
@@ -406,6 +411,14 @@
 			path = ViewModelTests;
 			sourceTree = "<group>";
 		};
+		DAD2178D2CB7D3E7004A6E78 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				DAD2178B2CB7CCC0004A6E78 /* SearchSuggestionManager.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
 		DAE8D9AF2919F2ED00931C32 /* Service */ = {
 			isa = PBXGroup;
 			children = (
@@ -477,6 +490,7 @@
 				DA34B6602922491800C052BD /* GitHubLanguageColor */,
 				DA2505AA2922136000C31B70 /* Stateful.swift */,
 				DA2505B32922235200C31B70 /* MessageError.swift */,
+				DAD217892CB7CB1F004A6E78 /* Array+RawRepresentable.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -576,7 +590,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = "YUMEMI Inc.";
 				TargetAttributes = {
 					BFD945DA244DC5E80012785A = {
@@ -665,6 +679,7 @@
 				DAE8D9C32919FCB000931C32 /* GitHubAPIServiceError.swift in Sources */,
 				DAE8D9EC291F82A400931C32 /* ContentView.swift in Sources */,
 				DAE8D9B62919F33B00931C32 /* GitHubAPIRequest.swift in Sources */,
+				DAD2178C2CB7CCC0004A6E78 /* SearchSuggestionManager.swift in Sources */,
 				DA2505AB2922136000C31B70 /* Stateful.swift in Sources */,
 				DAEE4CC729211D2E00123CB9 /* RepositoryDetailScreen.swift in Sources */,
 				DA29F6A32925BE5C00EBC58C /* GitHubAPIRequest+GetRepositoryDetail.swift in Sources */,
@@ -685,6 +700,7 @@
 				DAE8D9B12919F2F500931C32 /* HTTPMethod.swift in Sources */,
 				DA1F8B9629213ED9002B286C /* RepositoryCell.swift in Sources */,
 				DAE8D9BA2919F38D00931C32 /* GitHubAPIRequestProtocol.swift in Sources */,
+				DAD2178A2CB7CB1F004A6E78 /* Array+RawRepresentable.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				DAE8D9EA291F828F00931C32 /* EngineerCodeCheckApp.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
@@ -792,6 +808,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -854,6 +871,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
+++ b/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOSEngineerCodeCheck/Controllers/SearchSuggestionManager.swift
+++ b/iOSEngineerCodeCheck/Controllers/SearchSuggestionManager.swift
@@ -1,0 +1,48 @@
+//
+//  SearchSuggestionManager.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2024/10/10.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct SearchSuggestionManager {
+    
+    private let maxHistoryCount: Int = 3 // 履歴の最大記憶数
+    
+    let recommendedSuggestions: [String] = ["SwiftUI", "Swift", "Python", "Apple", "Qiita"]
+    
+    // 複数存在するようになった場合はこのIdentifiedなキーにすること
+    @AppStorage("searchHistories")
+    private(set) var historySuggestions: [String] = []            
+}
+
+// MARK: - History Methods
+
+extension SearchSuggestionManager {
+    
+    func addHistory(_ keyword: String) {
+        if keyword.isEmpty {
+            return
+        }
+        // 履歴にある場合は最新になるように再配置
+        if let index = historySuggestions.firstIndex(where: { $0 == keyword }) {
+            historySuggestions.remove(at: index)
+            historySuggestions.insert(keyword, at: 0)
+            return
+        }
+        
+        // 履歴になければ検索された語句を追加
+        historySuggestions.insert(keyword, at: 0)
+        // 履歴の上限を超えた分を古い順に削除
+        while historySuggestions.count > maxHistoryCount {
+            historySuggestions.removeLast()
+        }
+    }
+    
+    func removeAllHistories() {
+        historySuggestions.removeAll()
+    }
+}

--- a/iOSEngineerCodeCheck/Utils/Array+RawRepresentable.swift
+++ b/iOSEngineerCodeCheck/Utils/Array+RawRepresentable.swift
@@ -1,0 +1,35 @@
+//
+//  Array+RawRepresentable.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by HIROKI IKEUCHI on 2024/10/10.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+/*
+ refs:
+ [How to Store Nested Arrays in @AppStorage for SwiftUI](https://stackoverflow.com/questions/63166706/how-to-store-nested-arrays-in-appstorage-for-swiftui)
+ [Xcode 16 warning "Extension declares a conformance of imported type \.\.\. this will not behave correctly"](https://stackoverflow.com/questions/78612277/xcode-16-warning-extension-declares-a-conformance-of-imported-type-this-wil)
+ */
+extension Array: Swift.RawRepresentable where Element: Swift.Codable {
+    
+    public var rawValue: String {
+        guard let data = try? JSONEncoder().encode(self),
+              let result = String(data: data, encoding: .utf8)
+        else {
+            return "[]"
+        }
+        return result
+    }
+    
+    public init?(rawValue: String) {
+        guard let data = rawValue.data(using: .utf8),
+              let result = try? JSONDecoder().decode([Element].self, from: data)
+        else {
+            return nil
+        }
+        self = result
+    }
+}

--- a/iOSEngineerCodeCheck/ViewModels/SearchResultViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModels/SearchResultViewModel.swift
@@ -12,6 +12,7 @@ import Foundation
 @Observable
 final class SearchResultViewModel<GitHubAPIService>
 where GitHubAPIService: GitHubAPIServiceProtocol {
+    var keyword: String = ""
     private(set) var repositories: Stateful<[Repository]>
     private(set) var task: Task<(), Never>?
     
@@ -29,7 +30,7 @@ extension SearchResultViewModel {
         task = nil
     }
 
-    func searchButtonPressed(withKeyword keyword: String) async {
+    func searchButtonPressed() async {
         if keyword.isEmpty {
             return
         }

--- a/iOSEngineerCodeCheck/Views/RepositorySearchScreen/RepositorySearchScreen.swift
+++ b/iOSEngineerCodeCheck/Views/RepositorySearchScreen/RepositorySearchScreen.swift
@@ -11,25 +11,58 @@ import SwiftUI
 // Xcode16以上のビルドではViewに\@MainActorがつくので下記は不要となる
 @MainActor
 struct RepositorySearchScreen: View {
-
     @State private var viewModel: SearchResultViewModel<GitHubAPIService> = .init()
-    @State private var keyword = ""
+    @State private var searchSuggestionManager: SearchSuggestionManager = .init()
     internal let inspection = Inspection<Self>()
-
+    
     var body: some View {
         NavigationView {
             SearchResultView(viewModel: viewModel)
                 .navigationBarTitleDisplayMode(.inline)
-                .searchable(text: $keyword,
-                            placement: .automatic,
-                            prompt: "検索") {
-                }.onSubmit(of: .search) {
+                .searchable(text: $viewModel.keyword, placement: .navigationBarDrawer, prompt: "検索")
+                .searchSuggestions {
+                    searchSuggestions()
+                }
+                .onSubmit(of: .search) {
+                    searchSuggestionManager.addHistory(viewModel.keyword)
                     Task {
-                        await viewModel.searchButtonPressed(withKeyword: keyword)
+                        await viewModel.searchButtonPressed()
                     }
                 }
         }
         .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
+    }
+}
+
+// MARK: - Search Suggestions
+
+extension RepositorySearchScreen {
+    @ViewBuilder
+    private func searchSuggestions() -> some View {
+        Section("履歴") {
+            if searchSuggestionManager.historySuggestions.isEmpty {
+                Text("(なし)")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(searchSuggestionManager.historySuggestions, id: \.self) { history in
+                    Label(history, systemImage: "clock")
+                        .searchCompletion(history)
+                        .foregroundStyle(.primary)
+                    
+                }
+                Button("履歴のクリア") {
+                    searchSuggestionManager.removeAllHistories()
+                }
+                .frame(alignment: .trailing)
+            }
+        }
+        Section("おすすめ") {
+            ForEach(searchSuggestionManager.recommendedSuggestions, id: \.self) { suggestion in
+                Label(suggestion, systemImage: "magnifyingglass")
+                    .searchCompletion(suggestion)
+                    .foregroundStyle(.primary)
+            }
+        }
     }
 }
 

--- a/iOSEngineerCodeCheck/Views/RepositorySearchScreen/SearchResultView.swift
+++ b/iOSEngineerCodeCheck/Views/RepositorySearchScreen/SearchResultView.swift
@@ -21,11 +21,21 @@ struct SearchResultView: View {
         Group {
             switch viewModel.repositories {
             case .idle:
-                ReadyView()
+                if isSearching {
+                    // .searchSuggestionsの修飾ViewがListでないと表示が崩れるため
+                    List {}
+                } else {
+                    ReadyView()
+                }
             case .loading:
                 RepositoryListSkelton()
             case .failed(let error):
-                FailedView(error: error)
+                if isSearching {
+                    // .searchSuggestionsの修飾ViewがListでないと表示が崩れるため
+                    List {}
+                } else {
+                    FailedView(error: error)
+                }
             case let .loaded(repositories):
                 RepositoryList(repositories: repositories)
             }


### PR DESCRIPTION
## Issue

- N/A

## Overview

- Deprecatedな検索のmodifierを更新しました
- 検索の履歴や候補を表示するように改善しました

## Details (Optional)

https://github.com/user-attachments/assets/adfb5ddd-9f5b-4fa7-90cf-5c852f86051b

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [x] Resolve Xcode warning

## Reference(s) (Optional)

- [SwiftUIを用いた検索画面\(searchable, searchScopes, searchSuggestions\)](https://zenn.dev/zunda_pixel/articles/591fcfa876aa16)
